### PR TITLE
Allow swapping chrono dependency for time

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,21 +20,6 @@ jobs:
         with:
           command: check
 
-  all-features-test:
-    name: Test Suite (All Features)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all-features
-
   default-features-test:
     name: Test Suite (Default Features)
     runs-on: ubuntu-latest
@@ -48,6 +33,21 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
+
+  time-feature-test:
+    name: Test Suite (Only time feature)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features --features time
 
   extra-features-test:
     name: Test Suite (Time + All Other Features)

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,8 +20,8 @@ jobs:
         with:
           command: check
 
-  test:
-    name: Test Suite
+  all-features-test:
+    name: Test Suite (All Features)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -34,6 +34,35 @@ jobs:
         with:
           command: test
           args: --all-features
+
+  default-features-test:
+    name: Test Suite (Default Features)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+  extra-features-test:
+    name: Test Suite (Time + All Other Features)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features --features "time,gzip,test_json"
 
   fmt:
     name: Rustfmt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ serde_derive = "1.0"
 thiserror = "1.0"
 strum = "0.24"
 strum_macros = "0.24"
-cfg-if = "1.0.0"
 
 [dependencies.chrono]
 version = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,19 +10,26 @@ license = "MIT"
 exclude = ["tests/**/*.xml", "tests/**/*.xml.gz", "tests/**/*.json"]
 
 [features]
+default = ["chrono"]
+chrono = ["dep:chrono"]
+time = ["dep:time"]
 gzip = ["flate2"]
 test_json = ["serde_json"]
 
-
 [dependencies]
 url = { version = "2.1", features = ["serde"] }
-chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1.0", features = [ "derive" ] }
 xmltree = "0.10"
 serde_derive = "1.0"
 thiserror = "1.0"
 strum = "0.24"
 strum_macros = "0.24"
+cfg-if = "1.0.0"
+
+[dependencies.chrono]
+version = "0.4"
+features = ["serde"]
+optional = true
 
 [dependencies.flate2]
 version = "1.0"
@@ -30,4 +37,9 @@ optional = true
 
 [dependencies.serde_json]
 version = "1.0"
+optional = true
+
+[dependencies.time]
+version = "0.3.21"
+features = ["serde", "parsing", "formatting", "macros"]
 optional = true

--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@ Appstream files parser using Rust & [xmltree](https://docs.rs/xmltree/)
 
 Specifications: [https://www.freedesktop.org/software/appstream/docs/](https://www.freedesktop.org/software/appstream/docs/)
 
+The `chrono` or `time` crates can be used to represent dates. `chrono` is the default. To use `time` instead, turn off default features and enable the `time` feature, like this:
+
+```toml
+[dependencies]
+appstream = { version = "*", default-features = false, features = ["time"] }
+```
 
 How to use
 ```rust
@@ -19,7 +25,7 @@ fn main() -> Result<(), ParseError> {
     collection.components.iter()
         .filter(|c| c.extends.contains(&"org.gnome.gedit".into()))
         .collect::<Vec<&Component>>();
-        
+
     Ok(())
 }
-``` 
+```

--- a/src/builders.rs
+++ b/src/builders.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 
-use chrono::{DateTime, Utc};
 use url::Url;
 
 use super::{
@@ -8,6 +7,8 @@ use super::{
     Language, License, MarkupTranslatableString, Release, Requirement, Screenshot,
     TranslatableList, TranslatableString, Video,
 };
+
+use crate::DateTime;
 
 #[derive(Default, Debug)]
 /// A helper to build an `Artifact`.
@@ -628,9 +629,9 @@ impl LanguageBuilder {
 /// A helper to build a `Release`.
 pub struct ReleaseBuilder {
     /// The release date.
-    pub date: Option<DateTime<Utc>>,
+    pub date: Option<DateTime>,
     /// The end-of-life date of the release.
-    pub date_eol: Option<DateTime<Utc>>,
+    pub date_eol: Option<DateTime>,
     /// The release description.
     pub description: Option<MarkupTranslatableString>,
     /// The version of the release.
@@ -693,14 +694,14 @@ impl ReleaseBuilder {
 
     /// Sets the release date.
     #[must_use]
-    pub fn date(mut self, date: DateTime<Utc>) -> Self {
+    pub fn date(mut self, date: DateTime) -> Self {
         self.date = Some(date);
         self
     }
 
     /// Sets the End-of-life release date.
     #[must_use]
-    pub fn date_eol(mut self, date_eol: DateTime<Utc>) -> Self {
+    pub fn date_eol(mut self, date_eol: DateTime) -> Self {
         self.date_eol = Some(date_eol);
         self
     }

--- a/src/component.rs
+++ b/src/component.rs
@@ -201,7 +201,6 @@ impl Component {
 mod tests {
     use std::error::Error;
 
-    use chrono::{TimeZone, Utc};
     use url::Url;
 
     use super::Component;
@@ -368,7 +367,7 @@ mod tests {
             .translation(Translation::Gettext("@gettext-package@".into()))
             .release(
                 ReleaseBuilder::new("0.1.0")
-                    .date(Utc.with_ymd_and_hms(2019, 7, 11, 0, 0, 0).unwrap())
+                    .date(date(2019, 7, 11))
                     .build(),
             )
             .build();

--- a/src/component.rs
+++ b/src/component.rs
@@ -199,7 +199,6 @@ impl Component {
 
 #[cfg(test)]
 mod tests {
-
     use std::error::Error;
 
     use chrono::{TimeZone, Utc};
@@ -211,11 +210,12 @@ mod tests {
             ArtifactBuilder, ComponentBuilder, ImageBuilder, LanguageBuilder, ReleaseBuilder,
             ScreenshotBuilder,
         },
+        date,
         enums::{
             ArtifactKind, Bundle, Category, ComponentKind, ContentRatingVersion, FirmwareKind,
             Icon, ImageKind, Kudo, Launchable, ProjectUrl, Provide, ReleaseKind, Translation,
         },
-        ContentRating, MarkupTranslatableString, TranslatableList, TranslatableString,
+        timestamp, ContentRating, MarkupTranslatableString, TranslatableList, TranslatableString,
     };
 
     #[test]
@@ -323,7 +323,7 @@ mod tests {
             .release(
                 ReleaseBuilder::new("3.12.2")
                     .description(MarkupTranslatableString::with_default("<p>Fixes issues X, Y and Z</p>"))
-                    .date(Utc.with_ymd_and_hms(2013, 4, 12, 0, 0, 0).unwrap())
+                    .date(date(2013, 4, 12))
                     .build(),
             )
             .build();
@@ -432,7 +432,7 @@ mod tests {
             })
             .release(
                 ReleaseBuilder::new("3.0.2")
-                    .date(Utc.with_ymd_and_hms(2015, 2, 16, 0, 0, 0).unwrap())
+                    .date(date(2015, 2, 16))
                     .artifact(
                         ArtifactBuilder::default()
                         .url(Url::parse("http://www.hughski.com/downloads/colorhug-als/firmware/colorhug-als-3.0.2.cab")?)
@@ -491,11 +491,7 @@ mod tests {
             .provide(Provide::Library("libfoobar.so.2".into()))
             .provide(Provide::Font("foo.ttf".into()))
             .provide(Provide::Binary("foobar".into()))
-            .release(
-                ReleaseBuilder::new("1.2")
-                    .date(Utc.with_ymd_and_hms(2015, 2, 16, 0, 0, 0).unwrap())
-                    .build(),
-            )
+            .release(ReleaseBuilder::new("1.2").date(date(2015, 2, 16)).build())
             .build();
         assert_eq!(c1, c2);
         Ok(())
@@ -609,8 +605,8 @@ mod tests {
             .release(
                 ReleaseBuilder::new("9.0")
                     .description(MarkupTranslatableString::with_default("<p>Now contains the Linux kernel 4.9, GNOME 3.22, KDE Plasma 5, LibreOffice 5.2 and Qt 5.7. LXQt has been added.</p>"))
-                    .date(Utc.with_ymd_and_hms(2017, 7, 17, 0, 0, 0).unwrap())
-                    .date_eol(Utc.with_ymd_and_hms(2020, 7, 17, 0, 0, 0).unwrap())
+                    .date(date(2017, 7, 17))
+                    .date_eol(date(2020, 7, 17))
                     .build(),
             )
             .build();
@@ -640,7 +636,7 @@ mod tests {
             .release(ReleaseBuilder::new("10.0").build())
             .release(
                 ReleaseBuilder::new("9.0")
-                    .date(Utc.with_ymd_and_hms(2020, 01, 12, 0, 0, 0).unwrap())
+                    .date(date(2020, 01, 12))
                     .build(),
             )
             .build();
@@ -788,19 +784,19 @@ mod tests {
             })
             .release(
                 ReleaseBuilder::new("0.0.3")
-                    .date(Utc.datetime_from_str("1582329600", "%s")?)
+                    .date(timestamp("1582329600"))
                     .description(MarkupTranslatableString::with_default("<p>Stylesheet fixes</p><p>Translations updates</p>"))
                     .build()
             )
             .release(
                 ReleaseBuilder::new("0.0.2")
-                    .date(Utc.datetime_from_str("1566691200", "%s")?)
+                    .date(timestamp("1566691200"))
                     .description(MarkupTranslatableString::with_default("<p>Translations updates</p>"))
                     .build()
             )
             .release(
                 ReleaseBuilder::new("0.0.1")
-                    .date(Utc.datetime_from_str("1565136000", "%s")?)
+                    .date(timestamp("1565136000"))
                     .description(MarkupTranslatableString::with_default("<p>First release of Contrast</p>"))
                     .build()
             )

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,10 +15,6 @@ pub enum ParseError {
     /// url failed to parse a URL.
     UrlParseError(#[from] url::ParseError),
 
-    #[error("chrono parser error: {0}")]
-    /// url failed to parse a URL.
-    ChronoParseError(#[from] chrono::ParseError),
-
     #[error("Input/output error: {0} ")]
     /// IO.
     IOError(#[from] std::io::Error),

--- a/src/xml.rs
+++ b/src/xml.rs
@@ -1,6 +1,5 @@
 use std::{convert::TryFrom, str::FromStr};
 
-use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, TimeZone, Utc};
 use url::Url;
 use xmltree::{Element, XMLNode};
 
@@ -21,16 +20,33 @@ use super::{
     TranslatableString, Video,
 };
 
-fn deserialize_date(date: &str) -> Result<DateTime<Utc>, chrono::ParseError> {
-    Utc.datetime_from_str(date, "%s").or_else(
-        |_: chrono::ParseError| -> Result<DateTime<Utc>, chrono::ParseError> {
-            let date = NaiveDateTime::new(
-                NaiveDate::parse_from_str(date, "%Y-%m-%d")?,
-                NaiveTime::default(),
-            );
-            Ok(DateTime::<Utc>::from_utc(date, Utc))
-        },
-    )
+use crate::DateTime;
+
+cfg_if! {
+    if #[cfg(feature = "time")] {
+        fn deserialize_date(date: &str) -> Result<DateTime, time::error::Parse> {
+            use time::{macros::format_description, Date};
+
+            let timestamp_format = format_description!("[unix_timestamp]");
+            let date_format = format_description!("[year]-[month]-[day]");
+            DateTime::parse(date, &timestamp_format)
+                .or_else(|_| Date::parse(date, &date_format).map(|d| d.midnight().assume_utc()))
+        }
+    } else {
+        fn deserialize_date(date: &str) -> Result<DateTime, chrono::ParseError> {
+            use chrono::{NaiveDate, NaiveDateTime, NaiveTime, TimeZone, Utc};
+
+            Utc.datetime_from_str(date, "%s").or_else(
+                |_: chrono::ParseError| -> Result<DateTime, chrono::ParseError> {
+                    let date = NaiveDateTime::new(
+                        NaiveDate::parse_from_str(date, "%Y-%m-%d")?,
+                        NaiveTime::default(),
+                    );
+                    Ok(DateTime::from_utc(date, Utc))
+                },
+            )
+        }
+    }
 }
 
 impl TryFrom<&Element> for AppId {

--- a/src/xml.rs
+++ b/src/xml.rs
@@ -36,15 +36,15 @@ fn deserialize_date(date: &str) -> Result<DateTime, time::error::Parse> {
 fn deserialize_date(date: &str) -> Result<DateTime, chrono::ParseError> {
     use chrono::{NaiveDate, NaiveDateTime, NaiveTime, TimeZone, Utc};
 
-    Utc.datetime_from_str(date, "%s").or_else(
-        |_: chrono::ParseError| -> Result<DateTime, chrono::ParseError> {
-            let date = NaiveDateTime::new(
-                NaiveDate::parse_from_str(date, "%Y-%m-%d")?,
-                NaiveTime::default(),
-            );
-            Ok(DateTime::from_utc(date, Utc))
-        },
-    )
+    if let Ok(date) = NaiveDateTime::parse_from_str(date, "%s") {
+        Ok(Utc.from_utc_datetime(&date))
+    } else {
+        let date = NaiveDateTime::new(
+            NaiveDate::parse_from_str(date, "%Y-%m-%d")?,
+            NaiveTime::default(),
+        );
+        Ok(Utc.from_utc_datetime(&date))
+    }
 }
 
 impl TryFrom<&Element> for AppId {


### PR DESCRIPTION
Allows removing the `chrono` dependency and swapping it for the `time` crate instead if desired.